### PR TITLE
Switch return type so we can do something useful

### DIFF
--- a/BlazorServer/Pages/QueueDemo.razor.cs
+++ b/BlazorServer/Pages/QueueDemo.razor.cs
@@ -16,15 +16,12 @@ namespace BlazorServer.Pages
         [Inject]
         ISnackbar Snackbar { get; set; }
 
-        private async void AddItem()
+        private async Task AddItem()
         {
-            await Task.Run(() =>
-            {
-                string toAdd = Guid.NewGuid().ToString();
-                QueueManagement.AddItem(toAdd);
-                Snackbar.Configuration.PositionClass = Defaults.Classes.Position.TopCenter;
-                Snackbar.Add(toAdd + " added.", Severity.Normal);
-            });
+            string toAdd = Guid.NewGuid().ToString();
+            long numberOfItems = await QueueManagement.AddItem(toAdd);
+            Snackbar.Configuration.PositionClass = Defaults.Classes.Position.TopCenter;
+            Snackbar.Add(toAdd + " added. There are now " + numberOfItems + " in the list.", Severity.Normal);
         }
 
         private void RefreshQueueMembers()

--- a/MyServices/QueueManagementService.cs
+++ b/MyServices/QueueManagementService.cs
@@ -68,15 +68,13 @@ namespace MyServices
         /// Notify all connected subscribers that inventory of our queue has changed, after adding an item to the end of it.
         /// </summary>
         /// <param name="notification"></param>
-        public async void AddItem(string itemToAdd)
+        public async Task<long> AddItem(string itemToAdd)
         {
-            await Task.Run(() =>
-            {
-                _multiplexer.GetDatabase().ListRightPush(_listKey, itemToAdd);
-                string notification = "Queue contents changed {item} added to queue.";
-                _subscriber.Publish(_channel, notification);
-                _logger.LogInformation("Published '{notification}' to {channel}", notification, _channel);
-            });
+            long itemsInList = await _multiplexer.GetDatabase().ListRightPushAsync(_listKey, itemToAdd);               
+            string notification = "Queue contents changed {item} added to queue.";
+            _subscriber.Publish(_channel, notification);
+            _logger.LogInformation("Published '{notification}' to {channel}", notification, _channel);
+            return itemsInList;
         }
 
         /// <summary>


### PR DESCRIPTION
This replaces previously faulty idea of using task.Run to "provide async". See https://blog.stephencleary.com/2013/11/taskrun-etiquette-examples-using.html